### PR TITLE
Destroy the process during coroutine cancellation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,7 +90,7 @@ dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2")
 
-    testImplementation("org.amshove.kluent:kluent:1.61")
+    testImplementation("org.amshove.kluent:kluent:1.68")
     val junit5 = "5.7.1"
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junit5")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junit5")

--- a/src/main/kotlin/com/github/pgreze/process/Process.kt
+++ b/src/main/kotlin/com/github/pgreze/process/Process.kt
@@ -7,12 +7,11 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.isActive
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import java.io.File
@@ -73,12 +72,8 @@ suspend fun process(
             stderr == Redirect.CAPTURE ->
                 process.errorStream
             else -> null
-        }?.lineFlow { f ->
-            f.map {
-                yield() // https://github.com/Kotlin/kotlinx.coroutines/issues/320#issuecomment-380389449
-                it.also { consumer(it) }
-            }.toList()
-        } ?: emptyList()
+        }?.lineFlow { f -> f.map { it.also { consumer(it) } }.toList() }
+            ?: emptyList()
     }
 
     val input = async {
@@ -89,11 +84,11 @@ suspend fun process(
 
     try {
         @Suppress("UNCHECKED_CAST")
-        return@coroutineScopeIO ProcessResult(
+        ProcessResult(
             // Consume the output before waitFor,
             // ensuring no content is skipped.
             output = awaitAll(input, output).last() as List<String>,
-            resultCode = process.waitFor(),
+            resultCode = runInterruptible { process.waitFor() },
         )
     } catch (e: CancellationException) {
         process.destroy()

--- a/src/main/kotlin/com/github/pgreze/process/Process.kt
+++ b/src/main/kotlin/com/github/pgreze/process/Process.kt
@@ -72,8 +72,12 @@ suspend fun process(
             stderr == Redirect.CAPTURE ->
                 process.errorStream
             else -> null
-        }?.lineFlow { f -> f.map { it.also { consumer(it) } }.toList() }
-            ?: emptyList()
+        }?.lineFlow { f ->
+            f.map {
+                yield()
+                it.also { consumer(it) }
+            }.toList()
+        } ?: emptyList()
     }
 
     val input = async {

--- a/src/main/kotlin/com/github/pgreze/process/Process.kt
+++ b/src/main/kotlin/com/github/pgreze/process/Process.kt
@@ -1,16 +1,29 @@
 package com.github.pgreze.process
 
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 import java.io.File
 import java.io.InputStream
+
+private suspend fun <R> coroutineScopeIO(block: suspend CoroutineScope.() -> R) =
+    withContext(Dispatchers.IO) {
+        // Encapsulates all async calls in the current scope.
+        // https://elizarov.medium.com/structured-concurrency-722d765aa952
+        coroutineScope(block)
+    }
 
 @ExperimentalCoroutinesApi
 @Suppress("BlockingMethodInNonBlockingContext", "LongParameterList", "ComplexMethod")
@@ -19,13 +32,13 @@ suspend fun process(
     stdin: InputSource? = null,
     stdout: Redirect = Redirect.PRINT,
     stderr: Redirect = Redirect.PRINT,
-    /** Allowing to append new environment variables during this process's invocation. */
+    /** Extend with new environment variables during this process's invocation. */
     env: Map<String, String>? = null,
     /** Override the process working directory. */
     directory: File? = null,
     /** Consume without delay all streams configured with [Redirect.CAPTURE] */
     consumer: suspend (String) -> Unit = {},
-): ProcessResult = withContext(Dispatchers.IO) {
+): ProcessResult = coroutineScopeIO {
     // Based on the fact that it's hardcore to achieve manually:
     // https://stackoverflow.com/a/4959696
     val captureAll = stdout == stderr && stderr == Redirect.CAPTURE
@@ -60,8 +73,12 @@ suspend fun process(
             stderr == Redirect.CAPTURE ->
                 process.errorStream
             else -> null
-        }?.lineFlow { f -> f.map { it.also { consumer(it) } }.toList() }
-            ?: emptyList()
+        }?.lineFlow { f ->
+            f.map {
+                yield() // https://github.com/Kotlin/kotlinx.coroutines/issues/320#issuecomment-380389449
+                it.also { consumer(it) }
+            }.toList()
+        } ?: emptyList()
     }
 
     val input = async {
@@ -70,13 +87,18 @@ suspend fun process(
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
-    return@withContext ProcessResult(
-        // Consume the output before waitFor,
-        // ensuring no content is skipped.
-        output = awaitAll(input, output).last() as List<String>,
-        resultCode = process.waitFor(),
-    )
+    try {
+        @Suppress("UNCHECKED_CAST")
+        return@coroutineScopeIO ProcessResult(
+            // Consume the output before waitFor,
+            // ensuring no content is skipped.
+            output = awaitAll(input, output).last() as List<String>,
+            resultCode = process.waitFor(),
+        )
+    } catch (e: CancellationException) {
+        process.destroy()
+        throw e
+    }
 }
 
 private suspend fun <T> InputStream.lineFlow(block: suspend (Flow<String>) -> T): T =


### PR DESCRIPTION
Aiming to address #5 relying on the thread I opened in the Kotlin Slack: https://kotlinlang.slack.com/archives/C1CFAFJSK/p1627981249052500

#6 was initially proposed but it was not enough, because relying on a process with an active stdout (see the EndlessInputStream).
I considered several alternatives, including:
1. a 3rd async to regularly check the isActive state, and/or
1. add support for cancellation on all stdin/stdout operations, not just the stdout one.

At the end, have both should ensure cancelled operations for most cases.