### PR TITLE
Added destroyForcibly parameter

### DIFF
--- a/src/main/kotlin/com/github/pgreze/process/Process.kt
+++ b/src/main/kotlin/com/github/pgreze/process/Process.kt
@@ -35,6 +35,8 @@ suspend fun process(
     env: Map<String, String>? = null,
     /** Override the process working directory. */
     directory: File? = null,
+    /** Determine if process should be destroyed forcibly on job cancellation */
+    destroyForcibly: Boolean = false,
     /** Consume without delay all streams configured with [Redirect.CAPTURE] */
     consumer: suspend (String) -> Unit = {},
 ): ProcessResult = coroutineScopeIO {
@@ -95,7 +97,14 @@ suspend fun process(
             resultCode = runInterruptible { process.waitFor() },
         )
     } catch (e: CancellationException) {
-        process.destroy()
+        if(destroyForcibly)
+        {
+            process.destroyForcibly()
+        }
+        else
+        {
+            process.destroy()
+        }
         throw e
     }
 }


### PR DESCRIPTION
 for determining how process destruction should be handled in case of job cancellation, because of vararg as the first parameter and named arguments with default values this change is backwards compatible, it doesn't break existing code because by default process destruction is handled in the old way (by destroy() method)