### PR TITLE
Migrate to io.github.gradle-nexus.publish-plugin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,9 @@ jobs:
           export SIGNING_SECRET_KEY_RING_FILE=secret-key.gpg
           echo $SIGNING_SECRET_KEY_RING_CONTENT | base64 -di > $SIGNING_SECRET_KEY_RING_FILE
           ./gradlew assemble dokkaHtml
-          ./gradlew --max-workers 1 publishMavenPublicationToSonatypeRepository closeAndReleaseRepository
+          ./gradlew --max-workers 1 -Dorg.gradle.parallel=false \
+            publishMavenPublicationToSonatypeRepository \
+            closeAndReleaseSonatypeStagingRepository
       - name: Publish Dokka
         uses: netlify/actions/cli@master
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("io.gitlab.arturbosch.detekt")
     `maven-publish`
     signing
-    id("io.codearte.nexus-staging")
+    id("io.github.gradle-nexus.publish-plugin")
 }
 
 val myGroup = "com.github.pgreze"
@@ -133,10 +133,16 @@ signing {
     sign(publishing.publications)
 }
 
-// https://github.com/Codearte/gradle-nexus-staging-plugin
-nexusStaging {
-    packageGroup = myGroup
-    stagingProfileId = propOrEnv("sonatype.staging.profile.id", "SONATYPE_STAGING_PROFILE_ID")
-    username = ossrhUsername
-    password = ossrhPassword
+nexusPublishing {
+    packageGroup.set(myGroup)
+    repositories {
+        sonatype {
+            stagingProfileId.set(propOrEnv("sonatype.staging.profile.id", "SONATYPE_STAGING_PROFILE_ID"))
+            username.set(ossrhUsername)
+            password.set(ossrhPassword)
+            // Only for users registered in Sonatype after 24 Feb 2021
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+        }
+    }
 }

--- a/versions.properties
+++ b/versions.properties
@@ -13,7 +13,8 @@ plugin.org.jlleitschuh.gradle.ktlint=10.3.0
 
 plugin.io.gitlab.arturbosch.detekt=1.21.0
 
-plugin.io.codearte.nexus-staging=0.30.0
+# https://github.com/gradle-nexus/publish-plugin/
+plugin.io.github.gradle-nexus.publish-plugin=1.1.0
 
 version.kotlin=1.6.21
 ## # available=1.7.10


### PR DESCRIPTION
Following https://blog.solidsoft.pl/2021/02/26/unified-gradle-projects-releasing-to-maven-central-in-2021-migration-guide/