### PR TITLE
fix cancellation when stdout is consumed, see #23

### DIFF
--- a/src/main/kotlin/com/github/pgreze/process/Process.kt
+++ b/src/main/kotlin/com/github/pgreze/process/Process.kt
@@ -64,10 +64,14 @@ suspend fun process(
 
         // Handles async consumptions before the blocking output handling.
         if (stdout is Redirect.Consume) {
-            process.inputStream.lineFlow(charset, stdout.consumer)
+            async {
+                process.inputStream.lineFlow(charset, stdout.consumer)
+            }
         }
         if (stderr is Redirect.Consume) {
-            process.errorStream.lineFlow(charset, stderr.consumer)
+            async {
+                process.errorStream.lineFlow(charset, stderr.consumer)
+            }
         }
 
         val output = async {


### PR DESCRIPTION
Fixes #23 

It seems that the call to lineflow is blocking, so it does not pick up on coroutine capture. I also think this helps with another issue I have been noticing, that when I capture both stderr and stdout I get one of them as a batch at the end.